### PR TITLE
load-balancing: T1311: Delete load-balancing connections

### DIFF
--- a/src/lbdecision.cc
+++ b/src/lbdecision.cc
@@ -316,7 +316,9 @@ LBDecision::run(LBData &lb_data)
 
   //new request, bug 4112. flush conntrack tables if configured
   if (lb_data._flush_conntrack == true) {
-    execute("conntrack -F", stdout);
+    //execute("conntrack -F", stdout);
+    // Bug T1311 with "conntrack -F" and "conntrack-sync"
+    execute("conntrack --delete", stdout);
     execute("conntrack -F expect", stdout);
   }
 


### PR DESCRIPTION
Load-balancing WAN with conntrackd cannot flush connection
properly. It causes high CPU utilization and hang after commit
Replace Flush to Delete

https://phabricator.vyos.net/T1311