### PR TITLE
load-balancing: T4452: Changed `exclude` firewall statement

### DIFF
--- a/src/lbdecision.cc
+++ b/src/lbdecision.cc
@@ -328,9 +328,9 @@ LBDecision::run(LBData &lb_data)
     string app_cmd_local = get_application_cmd(iter->second,true,iter->second._exclude);
 
     if (iter->second._exclude == true) {
-      execute(string("iptables -t mangle -A WANLOADBALANCE_PRE ") + app_cmd + " -j ACCEPT", stdout);
+      execute(string("iptables -t mangle -A WANLOADBALANCE_PRE ") + app_cmd + " -j RETURN", stdout);
       if (lb_data._enable_local_traffic == true) {
-	execute(string("iptables -t mangle -A WANLOADBALANCE_OUT ") + app_cmd_local + " -j ACCEPT", stdout);
+	execute(string("iptables -t mangle -A WANLOADBALANCE_OUT ") + app_cmd_local + " -j RETURN", stdout);
       }
     }
     else {


### PR DESCRIPTION
The `ACCEPT` verdict statement is terminating one in nftables. So, after it, a
packet cannot be processed by any other rule in the same base chain. This breaks
compatibility with some features, like PBR.
This commit changes the statement to `RETURN`, which excludes packets from
load-balancing, but allows processing them by other rules in the parent base
chain.