### PR TITLE
T4173: load-balancing wan replace some iptables-nft rules

### DIFF
--- a/src/lbdecision.cc
+++ b/src/lbdecision.cc
@@ -110,10 +110,10 @@ if so then this stuff goes here!
   string stdout;
   //set up special nat rules
   if (lbdata._disable_source_nat == false) {
-    execute(string("iptables-nft -t nat -N WANLOADBALANCE"), stdout);
-    execute(string("iptables-nft -t nat -F WANLOADBALANCE"), stdout);
-    execute(string("iptables-nft -t nat -D VYOS_PRE_SNAT_HOOK -j WANLOADBALANCE"), stdout);
-    execute(string("iptables-nft -t nat -I VYOS_PRE_SNAT_HOOK 1 -j WANLOADBALANCE"), stdout);
+    execute(string("nft add chain ip nat WANLOADBALANCE"), stdout);
+    execute(string("nft flush chain ip nat WANLOADBALANCE"), stdout);
+    execute(string("nft flush chain ip nat VYOS_PRE_SNAT_HOOK"), stdout);
+    execute(string("nft insert rule ip nat VYOS_PRE_SNAT_HOOK counter jump WANLOADBALANCE"), stdout);
   }
   //set up the conntrack table
   execute(string("iptables-nft -t raw -N WLB_CONNTRACK"), stdout);
@@ -472,8 +472,9 @@ LBDecision::shutdown(LBData &data)
   }
 
   //clear out nat as well
-  execute("iptables-nft -t nat -F WANLOADBALANCE", stdout);
-  execute("iptables-nft -t nat -D VYOS_PRE_SNAT_HOOK -j WANLOADBALANCE", stdout);
+  execute("nft flush chain ip nat WANLOADBALANCE", stdout);
+  execute("nft delete chain ip nat WANLOADBALANCE", stdout);
+  execute("nft flush chain ip nat VYOS_PRE_SNAT_HOOK", stdout);
 
   //clear out conntrack hooks
   execute(string("iptables-nft -t raw -D PREROUTING -j WLB_CONNTRACK"), stdout);


### PR DESCRIPTION
There is some incompatibility with the current version of kernel/nftables and work of `iptables-nft`
It cannot insert/delete some new/exists rules via `iptables-nft`

https://vyos.dev/T4173#145851

Trying to Insert a rule 
**iptables: No chain/target/match by that name.**:
```
vyos@r14# sudo nft list table ip nat
# Warning: table ip nat is managed by iptables-nft, do not touch!
table ip nat {
	chain VYOS_PRE_SNAT_HOOK {
		type nat hook postrouting priority srcnat - 1; policy accept;
	}

	chain WANLOADBALANCE {
		ct mark 0xc9 counter packets 0 bytes 0 snat to 192.168.122.14
	}
}
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo iptables-nft -t nat -I VYOS_PRE_SNAT_HOOK 1 -j WANLOADBALANCE
iptables: No chain/target/match by that name.
[edit]
vyos@r14#
```
As result, `VYOS_PRE_SNAT_HOOK` not jumps to the chain `WANLOADBALANCE` so it never use SNAT


Trying to delete a rule
**iptables: Bad rule (does a matching rule exist in that chain?).**
```
vyos@r14:~$ sudo nft list table ip nat
# Warning: table ip nat is managed by iptables-nft, do not touch!
table ip nat {
	chain VYOS_PRE_SNAT_HOOK {
		type nat hook postrouting priority srcnat - 1; policy accept;
		counter packets 1 bytes 84 jump WANLOADBALANCE
		return
	}

	chain WANLOADBALANCE {
		ct mark 0xc9 counter packets 1 bytes 84 snat to 192.168.122.14
	}
}
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ sudo iptables-nft -t nat -D VYOS_PRE_SNAT_HOOK -j WANLOADBALANCE
iptables: Bad rule (does a matching rule exist in that chain?).
vyos@r14:~$ 
vyos@r14:~$
```

One mention that I know that it was working in `VyOS 1.4-rolling-202302010317, the first report that it doesn't work `1.4-rolling-202303170317` 
Replace some 'iptables-nft' rules with eq nftables rules to return the basic ability to load-balance traffic.


