### PR TITLE
T5209: Add sudo for user signal wan_lb PID

### DIFF
--- a/scripts/dhcp/04-dhcp-wanlb
+++ b/scripts/dhcp/04-dhcp-wanlb
@@ -1,4 +1,4 @@
 pid=/var/run/vyatta/wlb.pid
 if [ -f $pid ]; then
-	kill -s SIGUSR2 $( cat $pid ) 2>/dev/null
+	sudo kill -s SIGUSR2 $( cat $pid ) 2>/dev/null
 fi

--- a/scripts/ppp/04-ppp-wanlb
+++ b/scripts/ppp/04-ppp-wanlb
@@ -5,5 +5,5 @@ echo $5 > /var/run/load-balance/ppp/$6
 
 pid=/var/run/vyatta/wlb.pid
 if [ -f $pid ]; then
-	kill -s SIGUSR2 $( cat $pid ) 2>/dev/null
+	sudo kill -s SIGUSR2 $( cat $pid ) 2>/dev/null
 fi


### PR DESCRIPTION
Lack of privilegies for `kill -s SIGUSR2 $( cat $pid )`
it causes `04-dhcp-wanlb` hook exit with a nonzero exit code after renewing DHCP lease
* https://vyos.dev/T5209

To reproduce set address by dhcp , use load-balancing configuration:
```
set interfaces ethernet eth1 address 'dhcp'
set interfaces ethernet eth2 address 'dhcp'
set load-balancing wan interface-health eth1 failure-count '1'
set load-balancing wan interface-health eth1 nexthop 'dhcp'
set load-balancing wan interface-health eth1 success-count '1'
set load-balancing wan interface-health eth2 failure-count '1'
set load-balancing wan interface-health eth2 nexthop 'dhcp'
set load-balancing wan interface-health eth2 success-count '1'
set load-balancing wan rule 10 inbound-interface 'eth3'
set load-balancing wan rule 10 interface eth1
set load-balancing wan rule 10 interface eth2
set load-balancing wan rule 10 source address '198.51.100.0/24'
```
Force renew the DHCP address:
```
vyos@r14:~$ renew dhcp interface eth1
```
Before fix **/etc/dhcp/dhclient-exit-hooks.d/04-dhcp-wanlb returned non-zero exit status 1**:
```
May 08 12:40:37 r14 root[4623]: /etc/dhcp/dhclient-exit-hooks.d/04-dhcp-wanlb returned non-zero exit status 1
May 08 12:40:37 r14 systemd[1]: dhclient@eth1.service: Deactivated successfully.
May 08 12:40:37 r14 systemd[1]: Stopped dhclient@eth1.service - DHCP client on eth1.
May 08 12:40:37 r14 systemd[1]: Starting dhclient@eth1.service - DHCP client on eth1...
May 08 12:40:37 r14 systemd[1]: Started dhclient@eth1.service - DHCP client on eth1.
May 08 12:40:37 r14 sudo[4551]: pam_unix(sudo:session): session closed for user root
May 08 12:40:37 r14 dhclient-script-vyos[4628]: Current dhclient PID: 4627, Parent PID: 4626, IP version: 4, All dhclients for interface eth1: 4626 4627
May 08 12:40:37 r14 dhclient-script-vyos[4628]: Passing command to /usr/sbin/ip: "link set dev eth1 up"
May 08 12:40:37 r14 dhclient-script-vyos[4628]: No changes to apply via vyos-hostsd-client
May 08 12:40:37 r14 root[4656]: /etc/dhcp/dhclient-exit-hooks.d/04-dhcp-wanlb returned non-zero exit status 1
May 08 12:40:37 r14 dhclient[4627]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 5
May 08 12:40:40 r14 dhclient[4627]: DHCPOFFER of 192.168.100.254 from 192.168.100.1
May 08 12:40:40 r14 dhclient[4627]: DHCPREQUEST for 192.168.100.254 on eth1 to 255.255.255.255 port 67
May 08 12:40:40 r14 dhclient[4627]: DHCPACK of 192.168.100.254 from 192.168.100.1
```
After fix:
```
May 09 17:46:30 r14 systemd[1]: dhclient@eth1.service: Deactivated successfully.
May 09 17:46:30 r14 systemd[1]: Stopped dhclient@eth1.service - DHCP client on eth1.
May 09 17:46:30 r14 systemd[1]: Starting dhclient@eth1.service - DHCP client on eth1...
May 09 17:46:30 r14 systemd[1]: Started dhclient@eth1.service - DHCP client on eth1.
May 09 17:46:30 r14 sudo[17383]: pam_unix(sudo:session): session closed for user root
May 09 17:46:30 r14 dhclient-script-vyos[17460]: Current dhclient PID: 17459, Parent PID: 17457, IP version: 4, All dhclients for interface eth1: 17457 17459
May 09 17:46:30 r14 dhclient-script-vyos[17460]: Passing command to /usr/sbin/ip: "link set dev eth1 up"
May 09 17:46:30 r14 dhclient-script-vyos[17460]: No changes to apply via vyos-hostsd-client
May 09 17:46:30 r14 sudo[17488]:     root : PWD=/var/lib/dhcp ; USER=root ; COMMAND=/usr/bin/kill -s SIGUSR2 16404
May 09 17:46:30 r14 sudo[17488]: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
May 09 17:46:30 r14 wan_lb[16404]: User signal: 12
May 09 17:46:30 r14 wan_lb[16404]: wan_lb, rechecking interfaces..
May 09 17:46:30 r14 sudo[17488]: pam_unix(sudo:session): session closed for user root
May 09 17:46:30 r14 dhclient[17459]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 2
May 09 17:46:32 r14 dhclient[17459]: DHCPDISCOVER on eth1 to 255.255.255.255 port 67 interval 5
May 09 17:46:34 r14 dhclient[17459]: DHCPOFFER of 192.168.100.254 from 192.168.100.1
May 09 17:46:34 r14 dhclient[17459]: DHCPREQUEST for 192.168.100.254 on eth1 to 255.255.255.255 port 67
May 09 17:46:34 r14 dhclient[17459]: DHCPACK of 192.168.100.254 from 192.168.100.1

```